### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,12 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,12 +10,12 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38]
+    toxenvs: [py37, py38]
     os: linux
     pre_test:
     - task: UseRubyVersion@0

--- a/rubyvenv.py
+++ b/rubyvenv.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import functools
 import gzip
@@ -14,11 +16,8 @@ import urllib.request
 from typing import Callable
 from typing import ContextManager
 from typing import IO
-from typing import List
 from typing import NamedTuple
-from typing import Optional
 from typing import Sequence
-from typing import Tuple
 
 import distro
 
@@ -146,12 +145,12 @@ def get_platform_info() -> Platform:
 class GetsAHrefs(html.parser.HTMLParser):
     def __init__(self) -> None:
         super().__init__()
-        self.hrefs: List[Optional[str]] = []
+        self.hrefs: list[str | None] = []
 
     def handle_starttag(
             self,
             tag: str,
-            attrs: List[Tuple[str, Optional[str]]],
+            attrs: list[tuple[str, str | None]],
     ) -> None:
         if tag == 'a':
             self.hrefs.append(dict(attrs)['href'])
@@ -184,7 +183,7 @@ def _download_url(platform_info: Platform, version: str) -> str:
     )
 
 
-def get_prebuilt_versions(platform_info: Platform) -> Tuple[Version, ...]:
+def get_prebuilt_versions(platform_info: Platform) -> tuple[Version, ...]:
     url = platform_info.rvm_url
     resp = _decode_response(urllib.request.urlopen(url).read())
     parser = GetsAHrefs()
@@ -267,7 +266,7 @@ def make_system_environment(dest: str) -> int:
     return 0
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('dest', nargs='?', metavar='DEST_DIR')
     parser.add_argument('--ruby', default='latest')

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -25,7 +24,7 @@ classifiers =
 py_modules = rubyvenv
 install_requires =
     distro
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/testing/resources.py
+++ b/testing/resources.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os.path
 
 

--- a/tests/rubyvenv_test.py
+++ b/tests/rubyvenv_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import os
 import platform

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pre-commit
+envlist = py37,py38,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos